### PR TITLE
Restricting webpack version to 2.1.0-beta.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ts-loader": "^0.8.2",
     "typescript": "^2.0.2",
     "typings": "^1.3.3",
-    "webpack": "^2.1.0-beta.21",
+    "webpack": "2.1.0-beta.22",
     "webpack-dashboard": "^0.1.8",
     "webpack-dev-server": "^1.15.1",
     "webpack-merge": "^0.14.1",


### PR DESCRIPTION
As for now, `npm install` installs `beta.25` version which fails claiming that the webpack config file is invalid. It seems that the webpack team introduced some changes in `beta.23` which break on some configs: https://github.com/JeffreyWay/laravel-elixir-webpack-official/issues/17 .